### PR TITLE
Refactor naming conventions used in some functions.

### DIFF
--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -208,11 +208,11 @@ contract Rewards is Ownable {
         UserInfo storage user = ammLpUserInfo[_lpAddress][msg.sender];
         updateAmmRewardPool(_lpAddress);
         if (user.amount > 0) {
-            uint256 pending =
+            uint256 unclaimed =
                 user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(
                     user.rewardDebt
                 );
-            safeHaloTransfer(msg.sender, pending);
+            safeHaloTransfer(msg.sender, unclaimed);
         }
         IERC20(_lpAddress).transferFrom(
             address(msg.sender),
@@ -242,11 +242,11 @@ contract Rewards is Ownable {
         UserInfo storage user = minterLpUserInfo[_collateralAddress][_account];
         updateMinterRewardPool(_collateralAddress);
         if (user.amount > 0) {
-            uint256 pending =
+            uint256 unclaimed =
                 user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(
                     user.rewardDebt
                 );
-            safeHaloTransfer(_account, pending);
+            safeHaloTransfer(_account, unclaimed);
         }
         user.amount = user.amount.add(_amount);
         user.rewardDebt = user.amount.mul(pool.accHaloPerShare).div(DECIMALS);
@@ -266,11 +266,11 @@ contract Rewards is Ownable {
         UserInfo storage user = ammLpUserInfo[_lpAddress][msg.sender];
         require(user.amount >= _amount, "Error: Not enough balance");
         updateAmmRewardPool(_lpAddress);
-        uint256 pending =
+        uint256 unclaimed =
             user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(
                 user.rewardDebt
             );
-        safeHaloTransfer(msg.sender, pending);
+        safeHaloTransfer(msg.sender, unclaimed);
         user.amount = user.amount.sub(_amount);
         user.rewardDebt = user.amount.mul(pool.accHaloPerShare).div(DECIMALS);
         IERC20(_lpAddress).transfer(address(msg.sender), _amount);
@@ -295,11 +295,11 @@ contract Rewards is Ownable {
         UserInfo storage user = minterLpUserInfo[_collateralAddress][_account];
         require(user.amount >= _amount, "Error: Not enough balance");
         updateMinterRewardPool(_collateralAddress);
-        uint256 pending =
+        uint256 unclaimed =
             user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(
                 user.rewardDebt
             );
-        safeHaloTransfer(_account, pending);
+        safeHaloTransfer(_account, unclaimed);
         user.amount = user.amount.sub(_amount);
         user.rewardDebt = user.amount.mul(pool.accHaloPerShare).div(DECIMALS);
         emit WithdrawMinter(_account, _collateralAddress, _amount);
@@ -317,10 +317,10 @@ contract Rewards is Ownable {
 
         updateAmmRewardPool(_lpAddress);
 
-        uint256 pending = user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(user.rewardDebt);
+        uint256 unclaimed = user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(user.rewardDebt);
         user.rewardDebt = user.amount.mul(pool.accHaloPerShare).div(DECIMALS);
 
-        safeHaloTransfer(msg.sender, pending);
+        safeHaloTransfer(msg.sender, unclaimed);
 
     }
 
@@ -329,17 +329,17 @@ contract Rewards is Ownable {
     /// @param _collateralAddress
     /// @param _account
     /// @return
-    function withdrawPendingMinterLpRewards(address _collateralAddress, address _account) public onlyMinter {
+    function withdrawUnclaimedMinterLpRewards(address _collateralAddress, address _account) public onlyMinter {
 
         PoolInfo storage pool = minterLpPools[_collateralAddress];
         UserInfo storage user = minterLpUserInfo[_collateralAddress][_account];
 
         updateMinterRewardPool(_collateralAddress);
 
-        uint256 pending = user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(user.rewardDebt);
+        uint256 unclaimed = user.amount.mul(pool.accHaloPerShare).div(DECIMALS).sub(user.rewardDebt);
         user.rewardDebt = user.amount.mul(pool.accHaloPerShare).div(DECIMALS);
 
-        safeHaloTransfer(_account, pending);
+        safeHaloTransfer(_account, unclaimed);
 
     }
 
@@ -363,7 +363,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress
     /// @param _account
     /// @return
-    function getPendingPoolRewardsByUserByPool(
+    function getUnclaimedPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) public view returns (uint256) {
@@ -379,7 +379,7 @@ contract Rewards is Ownable {
     /// @param _collateralAddress
     /// @param _account
     /// @return
-    function pendingMinterLpUserRewards(
+    function getUnclaimedMinterLpRewardsByUser(
         address _collateralAddress,
         address _account
     ) public view returns (uint256) {
@@ -393,7 +393,7 @@ contract Rewards is Ownable {
     /// @notice
     /// @dev
     /// @return
-    function pendingVestingRewards() public view returns (uint256) {
+    function unclaimedVestingRewards() public view returns (uint256) {
 
 
 
@@ -544,10 +544,10 @@ contract Rewards is Ownable {
 
         uint256 thisMonthsReward = startingRewards.mul(exp(decayBase, nMonths)).div(DECIMALS);
         uint256 accHalo = (diffTime.mul(thisMonthsReward).div(DECIMALS)).add(accMonthlyHalo);
-        uint256 pending = (accHalo.sub(vestingRewardsDebt)).mul(vestingRewardsRatio).div(BPS);
+        uint256 unclaimed = (accHalo.sub(vestingRewardsDebt)).mul(vestingRewardsRatio).div(BPS);
         vestingRewardsDebt = accHalo.mul(vestingRewardsRatio).div(BPS);
-        safeHaloTransfer(haloChestContract, pending);
-        emit VestedRewardsReleased(pending, block.timestamp);
+        safeHaloTransfer(haloChestContract, unclaimed);
+        emit VestedRewardsReleased(unclaimed, block.timestamp);
     }
 
     /// @notice

--- a/contracts/Rewards.sol
+++ b/contracts/Rewards.sol
@@ -201,7 +201,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress
     /// @param _amount
     /// @return
-    function depositAmmLpTokens(address _lpAddress, uint256 _amount) public {
+    function depositPoolTokens(address _lpAddress, uint256 _amount) public {
 
         require(ammLpPools[_lpAddress].whitelisted == true, "Error: Amm Lp not allowed");
         PoolInfo storage pool = ammLpPools[_lpAddress];
@@ -259,7 +259,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress
     /// @param _amount
     /// @return
-    function withdrawAmmLpTokens(address _lpAddress, uint256 _amount) public {
+    function withdrawPoolTokens(address _lpAddress, uint256 _amount) public {
 
         //require(lpPools[_lpAddress].whitelisted == true, "Error: Amm Lp not allowed"); //#DISCUSS: Allow withdraw from later blacklisted lps
         PoolInfo storage pool = ammLpPools[_lpAddress];
@@ -310,7 +310,7 @@ contract Rewards is Ownable {
     /// @dev
     /// @param _lpAddress
     /// @return
-    function withdrawPendingAmmLpRewards(address _lpAddress) external {
+    function withdrawUnclaimedPoolRewards(address _lpAddress) external {
 
         PoolInfo storage pool = ammLpPools[_lpAddress];
         UserInfo storage user = ammLpUserInfo[_lpAddress][msg.sender];
@@ -363,7 +363,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress
     /// @param _account
     /// @return
-    function pendingAmmLpUserRewards(
+    function getPendingPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) public view returns (uint256) {

--- a/hardhat/contracts/Rewards.sol
+++ b/hardhat/contracts/Rewards.sol
@@ -680,53 +680,6 @@ contract Rewards is Ownable {
 
     }
 
-    /// @notice calculates the unclaimed rewards for last timestamp
-    /// @dev calculates the unclaimed rewards for last timestamp
-    /// @param _from last timestamp when rewards were updated
-    /// @return unclaimed rewards since last update
-    /* function calcReward(uint256 _from) internal returns (uint256){
-        uint256 currentTs = now;
-        //require(_from>=genesisTs, "from<genesisTs"); //TEMP
-        uint256 nMonthsStart = (_from.sub(genesisTs)).div(epochLength);
-        //require(currentTs>=genesisTs, "currentTs<genesisTs"); //TEMP
-        uint256 nMonthsEnd = (currentTs.sub(genesisTs)).div(epochLength);
-
-        //require(nMonthsEnd >= nMonthsStart, "Error: wrong timestamp");
-
-        if (nMonthsEnd == nMonthsStart) {
-            //require(currentTs>=_from, "currentTs<from"); //TEMP
-            uint256 diffTime = ((currentTs.sub(_from)).mul(DECIMALS)).div(epochLength);
-            uint256 monthlyReward = startingRewards.mul(exp(decayBase, nMonthsStart));
-            return diffTime.mul(monthlyReward).div(DECIMALS).div(DECIMALS);
-        }
-
-        else if (nMonthsEnd - nMonthsStart == 1) {
-            uint256 monthlyReward1 = startingRewards.mul(exp(decayBase, nMonthsStart));
-            uint256 monthlyReward2 = monthlyReward1.mul(decayBase).div(DECIMALS);
-            uint256 month1EndTs = genesisTs.add(nMonthsEnd.mul(epochLength));
-            //require(month1EndTs>_from, "month1EndTs<_from"); //TEMP
-            uint256 diffTime1 = ((month1EndTs.sub(_from)).mul(DECIMALS)).div(epochLength);
-            //require(currentTs>month1EndTs, "currentTs<month1EndTs"); //TEMP
-            uint256 diffTime2 = ((currentTs.sub(month1EndTs)).mul(DECIMALS)).div(epochLength);
-            return (diffTime1.mul(monthlyReward1).div(DECIMALS)).add(diffTime2.mul(monthlyReward2).div(DECIMALS)).div(DECIMALS);
-        }
-
-        else {
-            uint256 monthlyRewardStart = startingRewards.mul(exp(decayBase, nMonthsStart));
-            uint256 monthlyRewardEnd = startingRewards.mul(exp(decayBase, nMonthsEnd));
-            uint256 aggMonthlyRewards = aggregatedMonthlyRewards(monthlyRewardStart, nMonthsStart, nMonthsEnd);
-            uint256 month1EndTs = genesisTs.add((nMonthsStart+1).mul(epochLength));
-            uint256 month2EndTs = genesisTs.add((nMonthsEnd).mul(epochLength));
-            //require(month1EndTs>_from, "month1EndTs<_from agg"); //TEMP
-            uint256 diffTime1 = ((month1EndTs.sub(_from)).mul(DECIMALS)).div(epochLength);
-            //require(currentTs>month1EndTs, "currentTs<month1EndTs agg"); //TEMP
-            uint256 diffTime2 = ((currentTs.sub(month2EndTs)).mul(DECIMALS)).div(epochLength);
-            return ((diffTime1.mul(monthlyRewardStart).div(DECIMALS)).add(diffTime2.mul(monthlyRewardEnd).div(DECIMALS)).add(aggMonthlyRewards)).div(DECIMALS);
-        }
-
-    } */
-
-
     ///
     /// Calculates reward since last update timestamp based on the decay function
     /// Calculation works as follows:
@@ -769,22 +722,6 @@ contract Rewards is Ownable {
         return tillNow.sub(tillFrom);
 
     }
-
-    /* function aggregatedMonthlyRewards(
-        uint256 monthlyRewardStart,
-        uint256 nMonthsStart,
-        uint256 nMonthsEnd
-    ) internal view returns (uint256) {
-
-        uint256 aggMonthlyRewards;
-        uint256 monthlyReward = monthlyRewardStart;
-        for (uint256 i = nMonthsStart+1; i < nMonthsEnd; i++) {
-            monthlyReward = monthlyReward.mul(decayBase).div(DECIMALS);
-            aggMonthlyRewards = aggMonthlyRewards.add(monthlyReward);
-        }
-        return aggMonthlyRewards;
-
-    } */
 
     function exp(uint256 m, uint256 n) internal pure returns (uint256) {
         uint256 x = DECIMALS;

--- a/hardhat/contracts/Rewards.sol
+++ b/hardhat/contracts/Rewards.sol
@@ -522,7 +522,7 @@ contract Rewards is Ownable {
     /// @dev set alloc points for amm lp
     /// @param _lpAddress address of the lp token
     /// @param _allocPoint alloc points
-    function setAmmLpAlloc(
+    function setAmmLpAllocationPoints(
         address _lpAddress,
         uint256 _allocPoint
     ) public onlyOwner {
@@ -537,7 +537,7 @@ contract Rewards is Ownable {
     /// @dev set alloc points for minter lp
     /// @param _collateralAddress address of the collateral
     /// @param _allocPoint alloc points
-    function setMinterLpAlloc(
+    function setMinterLpAllocationPoints(
         address _collateralAddress,
         uint256 _allocPoint
     ) public onlyOwner {

--- a/hardhat/contracts/Rewards.sol
+++ b/hardhat/contracts/Rewards.sol
@@ -401,25 +401,25 @@ contract Rewards is Ownable {
     *             VIEW FUNCTIONS            *
     ****************************************/
 
-    /// @notice total amm lp alloc points
-    /// @dev total amm lp alloc points
-    /// @return total amm lp alloc points
-    function totalAmmLpAllocationPoints() public view returns (uint256) {
+    /// @notice total pool  alloc points
+    /// @dev total pool alloc points
+    /// @return total pool alloc points
+    function getTotalPoolAllocationPoints() public view returns (uint256) {
         return totalAmmLpAllocs;
     }
 
     /// @notice total minter lp alloc points
     /// @dev total minter lp alloc points
     /// @return total minter lp alloc points
-    function totalMinterLpAllocationPoints() public view returns (uint256) {
+    function getTotalMinterLpAllocationPoints() public view returns (uint256) {
         return totalMinterLpAllocs;
     }
 
-    /// @notice unclaimed amm lp rewards
-    /// @dev view function to check unclaimed amm lp rewards for an account
-    /// @param _lpAddress address of the amm lp token
+    /// @notice unclaimed pool rewards
+    /// @dev view function to check unclaimed pool rewards for an account
+    /// @param _lpAddress address of the pool token
     /// @param _account address of the user
-    /// @return unclaimed amm lp rewards for the user
+    /// @return unclaimed pool rewards for the user
     function getUnclaimedPoolRewardsByUserByPool(
         address _lpAddress,
         address _account

--- a/hardhat/contracts/Rewards.sol
+++ b/hardhat/contracts/Rewards.sol
@@ -259,7 +259,7 @@ contract Rewards is Ownable {
     /// @dev deposit amm lp tokens to earn rewards
     /// @param _lpAddress address of the amm lp token
     /// @param _amount amount of lp tokens
-    function depositAmmLpTokens(address _lpAddress, uint256 _amount) public {
+    function depositPoolTokens(address _lpAddress, uint256 _amount) public {
 
         require(ammLpPools[_lpAddress].whitelisted == true, "Error: Amm Lp not allowed");
         PoolInfo storage pool = ammLpPools[_lpAddress];
@@ -315,7 +315,7 @@ contract Rewards is Ownable {
     /// @dev withdraw amm lp tokens to earn rewards
     /// @param _lpAddress address of the amm lp token
     /// @param _amount amount of lp tokens
-    function withdrawAmmLpTokens(address _lpAddress, uint256 _amount) public {
+    function withdrawPoolTokens(address _lpAddress, uint256 _amount) public {
 
         //require(lpPools[_lpAddress].whitelisted == true, "Error: Amm Lp not allowed"); //#DISCUSS: Allow withdraw from later blacklisted lps
         PoolInfo storage pool = ammLpPools[_lpAddress];
@@ -364,7 +364,7 @@ contract Rewards is Ownable {
     /// @notice withdraw pending amm lp rewards
     /// @dev withdraw pending amm lp rewards, checks pending rewards, updates rewardDebt
     /// @param _lpAddress address of the amm lp token
-    function withdrawPendingAmmLpRewards(address _lpAddress) external {
+    function withdrawUnclaimedPoolRewards(address _lpAddress) external {
 
         PoolInfo storage pool = ammLpPools[_lpAddress];
         UserInfo storage user = ammLpUserInfo[_lpAddress][msg.sender];
@@ -420,7 +420,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress address of the amm lp token
     /// @param _account address of the user
     /// @return pending amm lp rewards for the user
-    function pendingAmmLpUserRewards(
+    function getPendingPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) public view returns (uint256) {
@@ -436,7 +436,7 @@ contract Rewards is Ownable {
     /// @param _lpAddress address of the amm lp token
     /// @param _account address of the user
     /// @return lp tokens deposited by user
-    function getUserLpTokens(
+    function getDepositedPoolTokenBalanceByUser(
         address _lpAddress,
         address _account
     ) public view returns (uint256){
@@ -509,7 +509,7 @@ contract Rewards is Ownable {
     /// @dev get total claimed halo by user
     /// @param _account address of the user
     /// @return total claimed halo by user
-    function getTotalClaimedHaloByUser(address _account) public view returns (uint256){
+    function getTotalRewardsClaimedByUser(address _account) public view returns (uint256){
         return claimedHalo[_account];
     }
 

--- a/hardhat/contracts/interfaces/IRewards.sol
+++ b/hardhat/contracts/interfaces/IRewards.sol
@@ -34,7 +34,7 @@ interface IRewards {
 
     function totalMinterLpAllocationPoints() external view returns (uint256);
 
-    function pendingAmmLpUserRewards(
+    function getPendingPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) external view returns (uint256);

--- a/hardhat/contracts/interfaces/IRewards.sol
+++ b/hardhat/contracts/interfaces/IRewards.sol
@@ -30,16 +30,16 @@ interface IRewards {
     //===============view functions==============//
     //===========================================//
 
-    function totalAmmLpAllocationPoints() external view returns (uint256);
+    function getTotalPoolAllocationPoints() external view returns (uint256);
 
-    function totalMinterLpAllocationPoints() external view returns (uint256);
+    function getTotalMinterLpAllocationPoints() external view returns (uint256);
 
     function getPendingPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) external view returns (uint256);
 
-    function pendingMinterLpUserRewards(
+    function getUnclaimedMinterLpRewardsByUser(
         address _collateralAddress,
         address _account
     ) external view returns (uint256);

--- a/hardhat/contracts/interfaces/IRewards.sol
+++ b/hardhat/contracts/interfaces/IRewards.sol
@@ -49,12 +49,12 @@ interface IRewards {
 
     function isValidMinterLp(address _collateralAddress) external view returns (bool);
 
-    function setAmmLpAlloc(
+    function setAmmLpAllocationPoints(
         address _lpAddress,
         uint256 _allocPoint
     ) external;
 
-    function setMinterLpAlloc(
+    function setMinterLpAllocationPoints(
         address _collateralAddress,
         uint256 _allocPoint
     ) external;

--- a/hardhat/package-lock.json
+++ b/hardhat/package-lock.json
@@ -1908,9 +1908,9 @@
       }
     },
     "env-paths": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true
     },
     "errno": {

--- a/hardhat/test/reward-test.js
+++ b/hardhat/test/reward-test.js
@@ -428,10 +428,10 @@ describe("As an Admin, I can update AMM LP pool’s allocation points", function
         expect(await rewardsContract.getTotalPoolAllocationPoints()).to.equal(10);
     })
     it("If caller is not contract owner, it should fail", async() => {
-        await expect(rewardsContract.connect(addr1).setAmmLpAlloc(lpTokenContract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
+        await expect(rewardsContract.connect(addr1).setAmmLpAllocationPoints(lpTokenContract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
     })
     it("If caller is contract owner, it should not fail; If AMM LP pool is whitelisted it should not fail; Set Amm LP pool allocs", async() => {
-        await expect(rewardsContract.connect(owner).setAmmLpAlloc(lpTokenContract.address, 5)).to.not.be.reverted;
+        await expect(rewardsContract.connect(owner).setAmmLpAllocationPoints(lpTokenContract.address, 5)).to.not.be.reverted;
     })
     it("AMM LP allocation points before", async() => {
         expect((await rewardsContract.getAmmLpPoolInfo(lpTokenContract.address)).allocPoint.toString()).to.equal('5');
@@ -449,10 +449,10 @@ describe("As an Admin, I can update minter lp collateral allocation points", fun
         expect(await rewardsContract.getTotalMinterLpAllocationPoints()).to.equal(10);
     })
     it("If caller is not contract owner, it should fail", async() => {
-        await expect(rewardsContract.connect(addr1).setMinterLpAlloc(collateralERC20Contract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
+        await expect(rewardsContract.connect(addr1).setMinterLpAllocationPoints(collateralERC20Contract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
     })
     it("If caller is contract owner, it should not fail; If collateral type is whitelisted it should not fail; Set Minter Lp pool allocs", async() => {
-        await expect(rewardsContract.connect(owner).setMinterLpAlloc(collateralERC20Contract.address, 5)).to.not.be.reverted;
+        await expect(rewardsContract.connect(owner).setMinterLpAllocationPoints(collateralERC20Contract.address, 5)).to.not.be.reverted;
     })
     it("DAI LP allocation points before", async() => {
         expect((await rewardsContract.getMinterLpPoolInfo(collateralERC20Contract.address)).allocPoint.toString()).to.equal('5');

--- a/hardhat/test/reward-test.js
+++ b/hardhat/test/reward-test.js
@@ -212,10 +212,10 @@ describe("When I deposit collateral tokens (DAI) on the Minter dApp, I start to 
         await rewardsContract.updateMinterRewardPool(collateralERC20Contract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const pendingMinterLpUserRewards = await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
+        const getUnclaimedMinterLpRewardsByUser = await rewardsContract.getUnclaimedMinterLpRewardsByUser(collateralERC20Contract.address, owner.address);
+        //console.log(ethers.utils.formatEther(unclaimedMinterLpUserRewards));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedMinterLpRewardsByUser(collateralERC20Contract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
     })
 
     it("I stop earning HALO tokens on withdrawing DAI", async() => {
@@ -234,10 +234,10 @@ describe("When I deposit collateral tokens (DAI) on the Minter dApp, I start to 
         await rewardsContract.updateMinterRewardPool(collateralERC20Contract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        //const pendingMinterLpUserRewards = await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
-        console.log("\tPending rewards for user after withdrawing DAI should be 0");
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address))))).to.equal(0);
+        //const unclaimedMinterLpUserRewards = await rewardsContract.unclaimedMinterLpUserRewards(collateralERC20Contract.address, owner.address);
+        //console.log(ethers.utils.formatEther(unclaimedMinterLpUserRewards));
+        console.log("\tUnclaimed rewards for user after withdrawing DAI should be 0");
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedMinterLpRewardsByUser(collateralERC20Contract.address, owner.address))))).to.equal(0);
 
     })
 
@@ -268,10 +268,10 @@ describe("When I supply liquidity to an AMM, I am able to receive my proportion 
         await rewardsContract.updateAmmRewardPool(lpTokenContract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const getPendingPoolRewardsByUserByPool = await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
+        const getUnclaimedPoolRewardsByUserByPool = await rewardsContract.getUnclaimedPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
+        //console.log(ethers.utils.formatEther(unclaimedMinterLpUserRewards));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
     })
 
     it("I stop earning HALO tokens on withdrawing LPT", async() => {
@@ -289,10 +289,10 @@ describe("When I supply liquidity to an AMM, I am able to receive my proportion 
         await rewardsContract.updateAmmRewardPool(lpTokenContract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        //const pendingMinterLpUserRewards = await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
-        console.log("\tPending rewards for user after withdrawing LPT should be 0");
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal(0);
+        //const unclaimedMinterLpUserRewards = await rewardsContract.unclaimedMinterLpUserRewards(collateralERC20Contract.address, owner.address);
+        //console.log(ethers.utils.formatEther(unclaimedMinterLpUserRewards));
+        console.log("\tUnclaimed rewards for user after withdrawing LPT should be 0");
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal(0);
 
     })
 
@@ -319,10 +319,10 @@ describe("I can view my unclaimed HALO tokens on the Minter dApp", function() {
         await rewardsContract.updateMinterRewardPool(collateralERC20Contract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const pendingMinterLpUserRewards = await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
+        const getUnclaimedMinterLpRewardsByUser = await rewardsContract.getUnclaimedMinterLpRewardsByUser(collateralERC20Contract.address, owner.address);
+        //console.log(ethers.utils.formatEther(unclaimedMinterLpUserRewards));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedMinterLpRewardsByUser(collateralERC20Contract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
 
     })
 
@@ -338,10 +338,10 @@ describe("I can view my unclaimed HALO tokens on the Minter dApp", function() {
         await rewardsContract.updateAmmRewardPool(lpTokenContract.address);
         updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const getPendingPoolRewardsByUserByPool = await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
-        //console.log(ethers.utils.formatEther(getPendingPoolRewardsByUserByPool));
+        const getUnclaimedPoolRewardsByUserByPool = await rewardsContract.getUnclaimedPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
+        //console.log(ethers.utils.formatEther(getUnclaimedPoolRewardsByUserByPool));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getUnclaimedPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
 
         //console.log(ethers.utils.formatEther(await haloTokenContract.balanceOf(owner.address)));
     })
@@ -358,8 +358,8 @@ describe("Earn vesting rewards by staking HALO inside HaloChest", function() {
         )).to.not.be.reverted;
     })
 
-    it("Send pending vested rewards to HaloChest", async() => {
-        const currVestedHalo = await rewardsContract.pendingVestingRewards();
+    it("Send unclaimed vested rewards to HaloChest", async() => {
+        const currVestedHalo = await rewardsContract.getUnclaimedVestingRewards();
         await expect(rewardsContract.releaseVestedRewards()).to.not.be.reverted;
     })
 
@@ -390,7 +390,7 @@ describe("Earn vesting rewards by staking HALO inside HaloChest", function() {
         sleep(3);
 
         console.log("Releasing vested bonus tokens to HaloChest from Rewards contract");
-        const currVestedHalo = (await rewardsContract.pendingVestingRewards()).toString();
+        const currVestedHalo = (await rewardsContract.getUnclaimedVestingRewards()).toString();
         console.log(currVestedHalo);
         await rewardsContract.releaseVestedRewards();
 

--- a/hardhat/test/reward-test.js
+++ b/hardhat/test/reward-test.js
@@ -183,8 +183,8 @@ describe("Check Contract Deployments", function() {
         expect(await haloChestContract.name()).to.equal("HaloChest");
     })
     it("Rewards Contract should be deployed", async() => {
-        expect(await rewardsContract.getTotalPoolRewardsAllocationPoints()).to.equal(10);
-        expect(await rewardsContract.totalMinterLpAllocationPoints()).to.equal(10);
+        expect(await rewardsContract.getTotalPoolAllocationPoints()).to.equal(10);
+        expect(await rewardsContract.getTotalMinterLpAllocationPoints()).to.equal(10);
         expect(await rewardsContract.isValidAmmLp(lpTokenContract.address)).to.equal(true);
         expect(await rewardsContract.isValidAmmLp(collateralERC20Contract.address)).to.equal(false);
         expect(await rewardsContract.isValidMinterLp(collateralERC20Contract.address)).to.equal(true);
@@ -425,7 +425,7 @@ describe("As an Admin, I can update AMM LP pool’s allocation points", function
         expect((await rewardsContract.getAmmLpPoolInfo(lpTokenContract.address)).allocPoint.toString()).to.equal('10');
     })
     it("Total LP allocation points before", async() => {
-        expect(await rewardsContract.totalAmmLpAllocationPoints()).to.equal(10);
+        expect(await rewardsContract.getTotalPoolAllocationPoints()).to.equal(10);
     })
     it("If caller is not contract owner, it should fail", async() => {
         await expect(rewardsContract.connect(addr1).setAmmLpAlloc(lpTokenContract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
@@ -437,7 +437,7 @@ describe("As an Admin, I can update AMM LP pool’s allocation points", function
         expect((await rewardsContract.getAmmLpPoolInfo(lpTokenContract.address)).allocPoint.toString()).to.equal('5');
     })
     it("expectedAllocPoints = (totalAllocPoints - currentAllocPoints) + newAllocPoints = 10 - 10 + 5", async() => {
-        expect(await rewardsContract.totalAmmLpAllocationPoints()).to.equal(5);
+        expect(await rewardsContract.getTotalPoolAllocationPoints()).to.equal(5);
     })
 })
 
@@ -446,7 +446,7 @@ describe("As an Admin, I can update minter lp collateral allocation points", fun
         expect((await rewardsContract.getMinterLpPoolInfo(collateralERC20Contract.address)).allocPoint.toString()).to.equal('10');
     })
     it("Total Minter LP allocation points before", async() => {
-        expect(await rewardsContract.totalMinterLpAllocationPoints()).to.equal(10);
+        expect(await rewardsContract.getTotalMinterLpAllocationPoints()).to.equal(10);
     })
     it("If caller is not contract owner, it should fail", async() => {
         await expect(rewardsContract.connect(addr1).setMinterLpAlloc(collateralERC20Contract.address, 5)).to.be.revertedWith('Ownable: caller is not the owner');
@@ -458,7 +458,7 @@ describe("As an Admin, I can update minter lp collateral allocation points", fun
         expect((await rewardsContract.getMinterLpPoolInfo(collateralERC20Contract.address)).allocPoint.toString()).to.equal('5');
     })
     it("expectedAllocPoints = (totalAllocPoints - currentAllocPoints) + newAllocPoints = 10 - 10 + 5", async() => {
-        expect(await rewardsContract.totalMinterLpAllocationPoints()).to.equal(5);
+        expect(await rewardsContract.getTotalMinterLpAllocationPoints()).to.equal(5);
     })
 })
 

--- a/hardhat/test/reward-test.js
+++ b/hardhat/test/reward-test.js
@@ -183,7 +183,7 @@ describe("Check Contract Deployments", function() {
         expect(await haloChestContract.name()).to.equal("HaloChest");
     })
     it("Rewards Contract should be deployed", async() => {
-        expect(await rewardsContract.totalAmmLpAllocationPoints()).to.equal(10);
+        expect(await rewardsContract.getTotalPoolRewardsAllocationPoints()).to.equal(10);
         expect(await rewardsContract.totalMinterLpAllocationPoints()).to.equal(10);
         expect(await rewardsContract.isValidAmmLp(lpTokenContract.address)).to.equal(true);
         expect(await rewardsContract.isValidAmmLp(collateralERC20Contract.address)).to.equal(false);

--- a/hardhat/test/reward-test.js
+++ b/hardhat/test/reward-test.js
@@ -255,7 +255,7 @@ describe("When I supply liquidity to an AMM, I am able to receive my proportion 
     it("I earn the correct number of HALO tokens per time interval on depositing LPT", async() => {
         //const haloBal = Math.round(ethers.utils.formatEther(await haloTokenContract.balanceOf(owner.address));
         haloBal = Math.round(parseFloat(ethers.utils.formatEther(await haloTokenContract.balanceOf(owner.address))));
-        await expect(rewardsContract.depositAmmLpTokens(
+        await expect(rewardsContract.depositPoolTokens(
             lpTokenContract.address,
             ethers.utils.parseEther('100')
         )).to.not.be.reverted;
@@ -268,15 +268,15 @@ describe("When I supply liquidity to an AMM, I am able to receive my proportion 
         await rewardsContract.updateAmmRewardPool(lpTokenContract.address);
         var updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const pendingAmmLpUserRewards = await rewardsContract.pendingAmmLpUserRewards(lpTokenContract.address, owner.address);
+        const getPendingPoolRewardsByUserByPool = await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
         //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingAmmLpUserRewards(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
     })
 
     it("I stop earning HALO tokens on withdrawing LPT", async() => {
 
-        await expect(rewardsContract.withdrawAmmLpTokens(
+        await expect(rewardsContract.withdrawPoolTokens(
             lpTokenContract.address,
             ethers.utils.parseEther('100')
         )).to.not.be.reverted;
@@ -292,7 +292,7 @@ describe("When I supply liquidity to an AMM, I am able to receive my proportion 
         //const pendingMinterLpUserRewards = await rewardsContract.pendingMinterLpUserRewards(collateralERC20Contract.address, owner.address);
         //console.log(ethers.utils.formatEther(pendingMinterLpUserRewards));
         console.log("\tPending rewards for user after withdrawing LPT should be 0");
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingAmmLpUserRewards(lpTokenContract.address, owner.address))))).to.equal(0);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal(0);
 
     })
 
@@ -327,7 +327,7 @@ describe("I can view my unclaimed HALO tokens on the Minter dApp", function() {
     })
 
     it("If LP tokens were deposited, display the correct number of HALO tokens rewards", async() => {
-        await expect(rewardsContract.depositAmmLpTokens(
+        await expect(rewardsContract.depositPoolTokens(
             lpTokenContract.address,
             ethers.utils.parseEther('100'),
         )).to.not.be.reverted;
@@ -338,10 +338,10 @@ describe("I can view my unclaimed HALO tokens on the Minter dApp", function() {
         await rewardsContract.updateAmmRewardPool(lpTokenContract.address);
         updateTxTs = (await ethers.provider.getBlock()).timestamp;
 
-        const pendingAmmLpUserRewards = await rewardsContract.pendingAmmLpUserRewards(lpTokenContract.address, owner.address);
-        //console.log(ethers.utils.formatEther(pendingAmmLpUserRewards));
+        const getPendingPoolRewardsByUserByPool = await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address);
+        //console.log(ethers.utils.formatEther(getPendingPoolRewardsByUserByPool));
 
-        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.pendingAmmLpUserRewards(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
+        expect(Math.round(parseFloat(ethers.utils.formatEther(await rewardsContract.getPendingPoolRewardsByUserByPool(lpTokenContract.address, owner.address))))).to.equal((updateTxTs-depositTxTs)*50000);
 
         //console.log(ethers.utils.formatEther(await haloTokenContract.balanceOf(owner.address)));
     })

--- a/interfaces/IRewards.sol
+++ b/interfaces/IRewards.sol
@@ -34,7 +34,7 @@ interface IRewards {
 
     function totalMinterLpAllocationPoints() external view returns (uint256);
 
-    function pendingAmmLpUserRewards(
+    function getPendingPoolRewardsByUserByPool(
         address _lpAddress,
         address _account
     ) external view returns (uint256);

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -85,7 +85,7 @@ def main():
     print(deposit_tx.events)
     # sleep(randint(20,30))
     update(rewards, ammLpToken.address, collateralERC20.address)
-    print(rewards.pendingAmmLpUserRewards(ammLpToken.address, accounts[0]))
+    print(rewards.getPendingPoolRewardsByUserByPool(ammLpToken.address, accounts[0]))
     print(rewards.getAmmLpPoolInfo(ammLpToken.address))
     print(rewards.getMinterLpPoolInfo(collateralERC20.address))
 

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -48,7 +48,7 @@ def main():
     #
     # sleep(randint(30,60))
     # update(rewards, ammLpToken_address, collateralERC20_address)
-    # print(rewards.pendingAmmLpUserRewards(ammLpToken_address, accounts[0]))
+    # print(rewards.getPendingPoolRewardsByUserByPool(ammLpToken_address, accounts[0]))
     # print(rewards.getAmmLpPoolInfo(ammLpToken_address))
 
 
@@ -61,7 +61,7 @@ def main():
     # print(deposit_tx.traceback())
     sleep(randint(30,60))
     update(rewards, ammLpToken_address, collateralERC20_address)
-    print(rewards.pendingAmmLpUserRewards(ammLpToken_address, accounts[0]))
+    print(rewards.getPendingPoolRewardsByUserByPool(ammLpToken_address, accounts[0]))
     print(rewards.getAmmLpPoolInfo(ammLpToken_address))
     print(rewards.getMinterLpPoolInfo(collateralERC20_address))
 


### PR DESCRIPTION
- Rename pendingAmmLpUserRewards to getPendingPoolRewardsByUserByPool
- Rename getUserLpTokens to getDepositedPoolTokenBalanceByUser
- Rename depositAmmLpTokens to depositPoolTokens
- Rename withdrawAMMLPTokens to withdrawPoolTokens
- Rename withdrawPendingAmmLpRewards to withdrawUnclaimedPoolRewards
- Rename getTotalClaimedByUser to getTotalRewardsClaimedByUser
